### PR TITLE
Bugfix: Using FileGpioConnectionDriver as non-root user

### DIFF
--- a/Raspberry.IO.GeneralPurpose/FileGpioConnectionDriver.cs
+++ b/Raspberry.IO.GeneralPurpose/FileGpioConnectionDriver.cs
@@ -50,7 +50,7 @@ namespace Raspberry.IO.GeneralPurpose
             using (var streamWriter = new StreamWriter(Path.Combine(gpioPath, "export"), false))
                 streamWriter.Write((int)pin);
 
-            var filePath = Path.Combine(gpioId, "direction");
+            var filePath = Path.Combine(gpioPath, gpioId, "direction");
             try {
                 SetPinDirection(filePath, direction);
             } catch (UnauthorizedAccessException) {
@@ -166,8 +166,8 @@ namespace Raspberry.IO.GeneralPurpose
 
         #region Private Helpers
 
-        private static void SetPinDirection(string filePath, PinDirection direction) {
-            using (var streamWriter = new StreamWriter(Path.Combine(gpioPath, filePath), false)) {
+        private static void SetPinDirection(string fullFilePath, PinDirection direction) {
+            using (var streamWriter = new StreamWriter(fullFilePath, false)) {
                 streamWriter.Write(direction == PinDirection.Input
                     ? "in"
                     : "out");


### PR DESCRIPTION
Hi,

I am currently working on a private project using the FileGpioConnectionDriver. When starting the c# program as non-root user I always get a UnauthorizedAccessException - even though the user is a group member of _gpio_. It seems that the system needs some time in order to set the appropriate file permissions to the new created gpio?/direction file.

``` bash
#!/bin/bash
echo "17" > /sys/class/gpio/unexport
echo "17" > /sys/class/gpio/export
#sleep 1 # uncomment this line and it will work
echo "out" > /sys/class/gpio/gpio17/direction
echo "1" > /sys/class/gpio/gpio17/value
```

When running this as test.sh shell script as non-root user I'll get permission errors.

``` bash
./test.sh: line 4: /sys/class/gpio/gpio17/direction: Permission denied
./test.sh: line 5: /sys/class/gpio/gpio17/value: Permission denied
```

Note: I am currently using Raspbian.

Same problem reported here: https://github.com/fivdi/onoff/issues/20

Greetings,
Daniel
