### PR TITLE
Added Banana Pi compatibility and support for Grove Chainable RGB Led

### DIFF
--- a/Raspberry.IO.Components/Leds/GroveRgb/GroveRgbConnection.cs
+++ b/Raspberry.IO.Components/Leds/GroveRgb/GroveRgbConnection.cs
@@ -1,0 +1,253 @@
+﻿#region References
+
+using System;
+using Raspberry.IO;
+using Raspberry.Timers;
+using Raspberry.IO.GeneralPurpose;
+using System.Collections.Generic;
+
+#endregion
+
+namespace Raspberry.IO.Components.Leds.GroveRgb
+{
+	/// <summary>
+	/// Represents a connection with Grove Chainable RGB Led modules.
+	/// @see http://www.seeedstudio.com/wiki/Grove_-_Chainable_RGB_LED
+	/// </summary>
+	public class GroveRgbConnection
+	{
+		#region Fields
+
+		IGpioConnectionDriver driver;
+		ProcessorPin dataPin;
+		ProcessorPin clockPin;
+		List<RgbColor> ledColors;
+
+		#endregion
+
+		#region Instance Management
+
+		public GroveRgbConnection(ConnectorPin dataPin, ConnectorPin clockPin, int ledCount)
+		{
+			ledColors = new List<RgbColor>();
+			for(int i = 0; i < ledCount; i++)
+			{
+				// Initialize all leds with white color
+				ledColors.Add(new RgbColor());
+			}
+			this.dataPin = dataPin.ToProcessor();
+			this.clockPin = clockPin.ToProcessor();
+			if (Raspberry.Board.Current.IsRaspberryPi) 
+			{
+				driver = new GpioConnectionDriver();
+			}
+			else 
+			{
+				driver = new FileGpioConnectionDriver();
+			}
+			driver.Allocate(this.dataPin, PinDirection.Output);
+			driver.Allocate(this.clockPin, PinDirection.Output);
+		}
+
+		#endregion
+
+
+		#region Methods
+
+		/// <summary>
+		/// Sets the color of a led.
+		/// </summary>
+		/// <param name="ledNumber">Led number (zero based index).</param>
+		/// <param name="red">Red.</param>
+		/// <param name="green">Green.</param>
+		/// <param name="blue">Blue.</param>
+		public void SetColorRgb(int ledNumber, byte red, byte green, byte blue)
+		{
+			// Send data frame prefix (32x "0")
+			SendByte(0x00);
+			SendByte(0x00);
+			SendByte(0x00);
+			SendByte(0x00);
+
+			// Send color data for each one of the leds
+			for (int i = 0; i < ledColors.Count; i++) 
+			{
+				if (i == ledNumber) 
+				{
+					ledColors[i].Red = red;
+					ledColors[i].Green = green;
+					ledColors[i].Blue = blue;
+				}
+
+				// Start by sending a byte with the format "1 1 /B7 /B6 /G7 /G6 /R7 /R6"
+				byte prefix = Convert.ToByte ("11000000", 2);
+				if ((blue & 0x80) == 0)
+					prefix |= Convert.ToByte ("00100000", 2);
+				if ((blue & 0x40) == 0)
+					prefix |= Convert.ToByte ("00010000", 2);
+				if ((green & 0x80) == 0)
+					prefix |= Convert.ToByte ("00001000", 2);
+				if ((green & 0x40) == 0)
+					prefix |= Convert.ToByte ("00000100", 2);
+				if ((red & 0x80) == 0)
+					prefix |= Convert.ToByte ("00000010", 2);
+				if ((red & 0x40) == 0)
+					prefix |= Convert.ToByte ("00000001", 2);
+
+				SendByte(prefix);
+
+				// Now must send the 3 colors
+				SendByte(ledColors[i].Blue);
+				SendByte(ledColors[i].Green);
+				SendByte(ledColors[i].Red);
+			}
+
+			// Terminate data frame (32x "0")
+			SendByte(0x00);
+			SendByte(0x00);
+			SendByte(0x00);
+			SendByte(0x00);
+		}
+
+		/// <summary>
+		/// Sets the color of a led.
+		/// </summary>
+		/// <param name="ledNumber">Led number (zero based index).</param>
+		/// <param name="h">Hue.</param>
+		/// <param name="s">Saturation.</param>
+		/// <param name="v">Value.</param>
+		public void SetColorHsv(int ledNumber, double h, double s, double v)
+		{
+			RgbColor color = HsvToRgb(h, s, v);
+			SetColorRgb(ledNumber, color.Red, color.Green, color.Blue);
+		}
+
+		#endregion
+
+		#region Private Helpers
+
+		private void SendByte(byte data)
+		{
+			// Send one bit at a time, starting with the MSB
+			for (byte i = 0; i < 8; i++) 
+			{
+				// If MSB is 1, write one and clock it, else write 0 and clock
+				if ((data & 0x80) != 0)
+					driver.Write(dataPin, true);
+				else
+					driver.Write(dataPin, false);
+
+				// clk():
+				driver.Write(clockPin, false);
+				HighResolutionTimer.Sleep(0.02m);
+				driver.Write(clockPin, true);
+				HighResolutionTimer.Sleep(0.02m);
+
+				// Advance to the next bit to send
+				data <<= 1;
+			}
+		}
+
+		private int Clamp(int i)
+		{
+			if (i < 0) i = 0;
+			if (i > 255) i = 255;
+			return i;
+		}
+
+		private RgbColor HsvToRgb(double hue, double sat, double val)
+		{
+			byte r = 0, g = 0, b = 0;
+			double H = hue * 360D;
+			while (H < 0) { H += 360; };
+			while (H >= 360) { H -= 360; };
+			double R, G, B;
+			if (val <= 0) 
+			{
+				R = G = B = 0; 
+			}
+			else if (sat <= 0)
+			{
+				R = G = B = val;
+			}
+			else
+			{
+				double hf = H / 60.0;
+				int i = (int)Math.Floor(hf);
+				double f = hf - i;
+				double pv = val * (1 - sat);
+				double qv = val * (1 - sat * f);
+				double tv = val * (1 - sat * (1 - f));
+				switch (i)
+				{
+				// Red is the dominant color
+				case 0:
+					R = val;
+					G = tv;
+					B = pv;
+					break;
+				// Green is the dominant color
+				case 1:
+					R = qv;
+					G = val;
+					B = pv;
+					break;
+				case 2:
+					R = pv;
+					G = val;
+					B = tv;
+					break;
+				// Blue is the dominant color
+				case 3:
+					R = pv;
+					G = qv;
+					B = val;
+					break;
+				case 4:
+					R = tv;
+					G = pv;
+					B = val;
+					break;
+				// Red is the dominant color
+				case 5:
+					R = val;
+					G = pv;
+					B = qv;
+					break;
+				// Just in case we overshoot on our math by a little, we put these here. Since its a switch it won't slow us down at all to put these here.
+				case 6:
+					R = val;
+					G = tv;
+					B = pv;
+					break;
+				case -1:
+					R = val;
+					G = pv;
+					B = qv;
+					break;
+				// The color is not defined, we should throw an error.
+				default:
+					R = G = B = val; // Just pretend its black/white
+					break;
+				}
+			}
+			r = (byte)Clamp((int)(R * 255.0));
+			g = (byte)Clamp((int)(G * 255.0));
+			b = (byte)Clamp((int)(B * 255.0));
+
+			return new RgbColor(){ Red = r, Green = g, Blue = b };
+		}
+
+		#endregion
+
+	}
+
+	public class RgbColor
+	{
+		public byte Red;
+		public byte Green;
+		public byte Blue;
+	}
+
+}
+

--- a/Raspberry.IO.Components/Raspberry.IO.Components.csproj
+++ b/Raspberry.IO.Components/Raspberry.IO.Components.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{8388CFCA-E3DB-43F7-B049-2CB195211CE8}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
@@ -33,20 +31,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Common.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Common.Logging.2.2.0\lib\net40\Common.Logging.dll</HintPath>
-    </Reference>
-    <Reference Include="Common.Logging.Core, Version=2.2.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Common.Logging.Core.2.2.0\lib\net40\Common.Logging.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Raspberry.System, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Raspberry.System.1.3.0\lib\net40\Raspberry.System.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="Common.Logging">
+      <HintPath>..\packages\Common.Logging.2.2.0\lib\net40\Common.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Common.Logging.Core">
+      <HintPath>..\packages\Common.Logging.Core.2.2.0\lib\net40\Common.Logging.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Raspberry.System">
+      <HintPath>..\packages\Raspberry.System.1.3.0\lib\net40\Raspberry.System.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\SharedAssemblyInfo.cs">
@@ -110,6 +105,7 @@
     <Compile Include="Sensors\VariableResistiveDividerConnection.cs" />
     <Compile Include="Sensors\Temperature\Tmp36\Tmp36Connection.cs" />
     <Compile Include="Sensors\ResistiveDivider.cs" />
+    <Compile Include="Leds\GroveRgb\GroveRgbConnection.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Raspberry.IO.InterIntegratedCircuit\Raspberry.IO.InterIntegratedCircuit.csproj">
@@ -125,9 +121,13 @@
       <Name>Raspberry.IO.SerialPeripheralInterface</Name>
     </ProjectReference>
     <ProjectReference Include="..\Raspberry.IO\Raspberry.IO.csproj">
-      <Project>{ace64f17-87e5-43e7-97a0-bdde19059c61}</Project>
+      <Project>{ACE64F17-87E5-43E7-97A0-BDDE19059C61}</Project>
       <Project>{D2E41147-5BF6-4109-A497-C76284F3C020}</Project>
       <Name>Raspberry.IO</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Raspberry.IO.GeneralPurpose\Raspberry.IO.GeneralPurpose.csproj">
+      <Project>{281C71ED-C36D-408E-8BAA-75C381DC17E7}</Project>
+      <Name>Raspberry.IO.GeneralPurpose</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
@@ -143,4 +143,8 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <ItemGroup>
+    <Folder Include="Leds\" />
+    <Folder Include="Leds\GroveRgb\" />
+  </ItemGroup>
 </Project>

--- a/Raspberry.IO.GeneralPurpose/FileGpioConnectionDriver.cs
+++ b/Raspberry.IO.GeneralPurpose/FileGpioConnectionDriver.cs
@@ -28,8 +28,8 @@ namespace Raspberry.IO.GeneralPurpose
         /// </summary>
         public FileGpioConnectionDriver()
         {
-            if (!Board.Current.IsRaspberryPi)
-                throw new NotSupportedException("FileGpioConnectionDriver is only supported on Raspberry Pi");
+			if (System.Environment.OSVersion.Platform != PlatformID.Unix)
+                throw new NotSupportedException("FileGpioConnectionDriver is only supported in Unix");
         }
 
         #endregion

--- a/Raspberry.IO.GeneralPurpose/GpioConnectionSettings.cs
+++ b/Raspberry.IO.GeneralPurpose/GpioConnectionSettings.cs
@@ -141,7 +141,7 @@ namespace Raspberry.IO.GeneralPurpose
                 var configurationSection = ConfigurationManager.GetSection("gpioConnection") as GpioConnectionConfigurationSection;
                 return configurationSection != null && !String.IsNullOrEmpty(configurationSection.DriverTypeName)
                            ? (IGpioConnectionDriver) Activator.CreateInstance(Type.GetType(configurationSection.DriverTypeName, true))
-                           : new GpioConnectionDriver();
+						: (Raspberry.Board.Current.IsRaspberryPi ? (IGpioConnectionDriver)new GpioConnectionDriver() : (IGpioConnectionDriver)new FileGpioConnectionDriver());
             }
         }
 

--- a/UnitTests/Tests.Raspberry.IO.SerialPeripheralInterface/SpiTransferBufferSpecs.cs
+++ b/UnitTests/Tests.Raspberry.IO.SerialPeripheralInterface/SpiTransferBufferSpecs.cs
@@ -224,7 +224,7 @@ namespace Tests.Raspberry.IO.SerialPeripheralInterface.SpiTransferBufferSpecs
         [Test]
         public void Should_the_control_structure_have_the_requested_chip_select_change_value() {
             // ReSharper disable once UnreachableCode
-            buffer.ControlStructure.ChipSelectChange.Should().Be(REQUESTED_CHIP_SELECT_CHANGE ? 1 : 0);
+			buffer.ControlStructure.ChipSelectChange.Should().Be(REQUESTED_CHIP_SELECT_CHANGE ? (byte)1 : (byte)0);
         }
 
         [Test]


### PR DESCRIPTION
- fixed compile error in file SpiTransferBufferSpecs.cs (missing explicit cast at line 227)
- FileGpioConnection: replaced Raspberry specific platform check against a generic Unix check (this make it compatible with other /sys/class/gpio compatible platforms, eg. Banana Pi)
- Added Default driver fallback to FileGpioConnection on non-Raspberry Pi systems
- Added support for Grove Chainable RGB Led modules
