### PR TITLE
adding support for DS18B20 1-wire temperature sensor

### DIFF
--- a/Raspberry.IO.Components/Raspberry.IO.Components.csproj
+++ b/Raspberry.IO.Components/Raspberry.IO.Components.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Sensors\Pressure\Bmp085\Bmp085Precision.cs" />
     <Compile Include="Sensors\Temperature\Dht\DhtConnection.cs" />
     <Compile Include="Sensors\Temperature\Dht\DhtData.cs" />
+    <Compile Include="Sensors\Temperature\Ds18b20\Ds18b20Connection.cs" />
     <Compile Include="Sensors\VariableResistiveDividerConnection.cs" />
     <Compile Include="Sensors\Temperature\Tmp36\Tmp36Connection.cs" />
     <Compile Include="Sensors\ResistiveDivider.cs" />

--- a/Raspberry.IO.Components/Sensors/Temperature/Ds18b20/Ds18b20Connection.cs
+++ b/Raspberry.IO.Components/Sensors/Temperature/Ds18b20/Ds18b20Connection.cs
@@ -1,0 +1,135 @@
+﻿#region References
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+
+#endregion
+
+namespace Raspberry.IO.Components.Sensors.Temperature.Ds18b20
+{
+    /// <summary>
+    /// Represents a connection to a DS18B20 temperature sensor.
+    /// </summary>
+    /// <remarks>See <see cref="https://learn.adafruit.com/adafruits-raspberry-pi-lesson-11-ds18b20-temperature-sensing"/>.</remarks>
+    public class Ds18b20Connection : IDisposable
+    {
+        #region Fields
+
+        private readonly string _deviceFolder;
+        private string DeviceFile { get {return _deviceFolder + @"/w1_slave";} }
+        private const string BaseDir = @"/sys/bus/w1/devices/";
+
+        #endregion
+
+        #region Instance Management
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Ds18b20Connection"/> class.
+        /// </summary>
+        public Ds18b20Connection(string deviceId)
+        {
+            _deviceFolder = BaseDir + deviceId;
+            if (!Directory.Exists(_deviceFolder))
+            {
+                throw new ArgumentException(string.Format("Sensor with Id {0} not found. {1}", deviceId, ModprobeExceptionMessage), deviceId);
+            }
+
+        }
+
+        private string ModprobeExceptionMessage
+        {
+            get
+            {
+                var sb = new StringBuilder();
+                sb.AppendLine("Make sure you have loaded the required kernel models.");
+                sb.AppendFormat("\tmodprobe w1-gpio{0}", Environment.NewLine);
+                sb.AppendFormat("\tmodprobe w1-therm{0}", Environment.NewLine);
+                return sb.ToString();
+            }
+        }
+
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Ds18b20Connection"/> class.
+        /// </summary>
+        public Ds18b20Connection(int deviceIndex)
+        {
+            var deviceFolders = Directory.GetDirectories(BaseDir, "28*").ToList();
+            var deviceCount = deviceFolders.Count();
+            if (deviceCount == 0)
+            {
+                throw new InvalidOperationException(string.Format("No sensors were found in {0}. {1}", BaseDir, ModprobeExceptionMessage));
+            }
+
+            if (deviceCount <= deviceIndex)
+            {
+                throw new IndexOutOfRangeException(string.Format("There were only {0} devices found, so index {1} is invalid", deviceCount, deviceIndex ));
+            }
+
+            _deviceFolder = deviceFolders[deviceIndex];
+
+        }
+
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        void IDisposable.Dispose()
+        {
+            Close();
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Gets the temperature, in Celsius.
+        /// </summary>
+        /// <returns>The temperature, in Celsius.</returns>
+        public double GetTemperatureCelsius()
+        {
+            var lines = File.ReadAllLines(DeviceFile);
+            while (!lines[0].Trim().EndsWith("YES"))
+            {
+                Thread.Sleep(2);
+                lines = File.ReadAllLines(DeviceFile);
+            }
+
+            var equalsPos = lines[1].IndexOf("t=");
+            if (equalsPos == -1)
+            {
+                throw new Exception("invalid temp reading");
+            }
+
+            var temperatureString = lines[1].Substring(equalsPos + 2);
+            var tempC = Double.Parse(temperatureString) / 1000.0;
+            return tempC;
+
+        }
+
+        /// <summary>
+        /// Gets the temperature, in Fahrenheit.
+        /// </summary>
+        /// <returns>The temperature, in Fahrenheit.</returns>
+        public double GetTemperatureFahrenheit()
+        {
+            var tempC = GetTemperatureCelsius();
+            var tempF = tempC * 9.0 / 5.0 + 32.0;
+            return tempF;
+        }
+
+
+        /// <summary>
+        /// Closes this instance.
+        /// </summary>
+        public void Close()
+        {
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
# DS18B20 support

I've added support for the DS18B20 1-wire temperature sensor, based on the write-up found here; https://learn.adafruit.com/adafruits-raspberry-pi-lesson-11-ds18b20-temperature-sensing

## Usage
You can see this in use [in my GaragePi project](https://github.com/johnmwright/GaragePi/blob/master/dotNet/GaragePi/TempSensorController.cs)

Usage is similar to other components in this library, except that no pin information is needed since the 1-wire kernel driver does all the work for you.  You just need to provide the sensors unique serial number, or a zero-based index for the sensor to use.

Example:

        var sensorIndex = 0;
        using( Ds18b20Connection _driver = new Ds18b20Connection(sensorIndex)
        {
             var tempF = _driver.GetTemperatureFahrenheit();
        }

## Prereq

Since it does utilize the 1-wire kernel drivers, the user will need to use modprobe to load them ahead of running the app.  Note that the class constructor will include this in the exception message if it can't find the sensor requested.

          modprobe w1-gpio
          modprobe w1-therm
      