### PR TITLE
Add support for the MCP23008 I/O extender used by the Adafruit I2C/SPI Serial backpack

### DIFF
--- a/Raspberry.IO.Components/Expanders/Mcp23008/Mcp23008I2cConnection.cs
+++ b/Raspberry.IO.Components/Expanders/Mcp23008/Mcp23008I2cConnection.cs
@@ -1,0 +1,177 @@
+﻿#region References
+
+using Raspberry.IO.InterIntegratedCircuit;
+
+#endregion
+
+namespace Raspberry.IO.Components.Expanders.Mcp23008
+{
+    /// <summary>
+    /// Represents a I2C connection to a MCP23008 I/O Expander.
+    /// </summary>
+    /// <remarks>See <see cref="http://www.adafruit.com/datasheets/MCP23008.pdf"/> for more information.</remarks>
+    public class Mcp23008I2cConnection
+    {
+        #region Fields
+
+        private readonly I2cDeviceConnection connection;
+
+        #endregion
+
+        #region Instance Management
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Mcp23008I2cConnection"/> class.
+        /// </summary>
+        /// <param name="connection">The connection.</param>
+        public Mcp23008I2cConnection(I2cDeviceConnection connection)
+        {
+            this.connection = connection;
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Sets the direction.
+        /// </summary>
+        /// <param name="pin">The pin.</param>
+        /// <param name="direction">The direction.</param>
+        public void SetDirection(Mcp23008Pin pin, Mcp23008PinDirection direction)
+        {
+            var register = Register.IODIR;
+
+            connection.WriteByte((byte)register);
+            var directions = connection.ReadByte();
+
+            var bit = (byte)((int)pin & 0xFF);
+            var newDirections = (direction == Mcp23008PinDirection.Input)
+                                    ? directions | bit
+                                    : directions & ~bit;
+
+            connection.Write(new[] { (byte)register, (byte)newDirections });
+        }
+
+        /// <summary>
+        /// Sets the polarity.
+        /// </summary>
+        /// <param name="pin">The pin.</param>
+        /// <param name="polarity">The polarity.</param>
+        public void SetPolarity(Mcp23008Pin pin, Mcp23008PinPolarity polarity)
+        {
+            var register = Register.IPOL;
+
+            connection.WriteByte((byte)register);
+            var polarities = connection.ReadByte();
+
+            var bit = (byte)((int)pin & 0xFF);
+            var newPolarities = (polarity == Mcp23008PinPolarity.Inverted)
+                                    ? polarities | bit
+                                    : polarities & ~bit;
+
+            connection.Write(new[] { (byte)register, (byte)newPolarities });
+        }
+
+        /// <summary>
+        /// Sets the resistor.
+        /// </summary>
+        /// <param name="pin">The pin.</param>
+        /// <param name="resistor">The resistor.</param>
+        public void SetResistor(Mcp23008Pin pin, Mcp23008PinResistor resistor)
+        {
+            var register = Register.GPPU;
+
+            connection.WriteByte((byte)register);
+            var resistors = connection.ReadByte();
+
+            var bit = (byte)((int)pin & 0xFF);
+            var newResistors = (resistor == Mcp23008PinResistor.PullUp)
+                                   ? resistors | bit
+                                   : resistors & ~bit;
+
+            connection.Write(new[] { (byte)register, (byte)newResistors });
+        }
+
+        /// <summary>
+        /// Sets the pin status.
+        /// </summary>
+        /// <param name="pin">The pin.</param>
+        /// <param name="enabled">if set to <c>true</c>, pin is enabled.</param>
+        public void SetPinStatus(Mcp23008Pin pin, bool enabled)
+        {
+            var register = Register.GPIO;
+
+            connection.WriteByte((byte)register);
+            var status = connection.ReadByte();
+
+            var bit = (byte)((int)pin & 0xFF);
+            var newStatus = enabled
+                                ? status | bit
+                                : status & ~bit;
+
+            connection.Write((byte)register, (byte)newStatus);
+        }
+
+
+        /// <summary>
+        /// Gets the pin status.
+        /// </summary>
+        /// <param name="pin">The pin.</param>
+        /// <returns>The pin status.</returns>
+        public bool GetPinStatus(Mcp23008Pin pin)
+        {
+            var register = Register.GPIO;
+
+            connection.WriteByte((byte)register);
+            var status = connection.ReadByte();
+
+            var bit = (byte)((int)pin & 0xFF);
+            return (status & bit) != 0x00;
+        }
+
+        /// <summary>
+        /// Toogles the specified pin.
+        /// </summary>
+        /// <param name="pin">The pin.</param>
+        public void Toogle(Mcp23008Pin pin)
+        {
+            var register = Register.GPIO;
+
+            connection.WriteByte((byte)register);
+            var status = connection.ReadByte();
+
+            var bit = (byte)((int)pin & 0xFF);
+            var bitEnabled = (status & bit) != 0x00;
+            var newBitEnabled = !bitEnabled;
+
+            var newStatus = newBitEnabled
+                                ? status | bit
+                                : status & ~bit;
+
+            connection.Write((byte)register, (byte)newStatus);
+        }
+
+        #endregion
+
+        #region Private Helpers
+
+        private enum Register
+        {
+            IODIR = 0x00,
+            IPOL = 0x01,
+            GPINTEN = 0x02,
+            DEFVAL = 0x03,
+            INTCON = 0x04,
+            IOCON = 0x05,
+            GPPU = 0x06,
+            INTF = 0x07,
+            INTCAP = 0x08,
+            GPIO = 0x09,
+            OLAT = 0x0A
+        }
+
+        #endregion
+
+    }
+}

--- a/Raspberry.IO.Components/Expanders/Mcp23008/Mcp23008InputBinaryPin.cs
+++ b/Raspberry.IO.Components/Expanders/Mcp23008/Mcp23008InputBinaryPin.cs
@@ -1,0 +1,89 @@
+﻿#region References
+
+using System;
+
+#endregion
+
+namespace Raspberry.IO.Components.Expanders.Mcp23008
+{
+    /// <summary>
+    /// Represents a binary intput pin on a MCP23017 I/O expander.
+    /// </summary>
+    public class Mcp23008InputBinaryPin : IInputBinaryPin
+    {
+        #region Fields
+
+        private readonly Mcp23008I2cConnection connection;
+        private readonly Mcp23008Pin pin;
+
+        /// <summary>
+        /// The default timeout (5 seconds).
+        /// </summary>
+        public static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(5);
+
+        #endregion
+
+        #region Instance Management
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Mcp23008InputBinaryPin"/> class.
+        /// </summary>
+        /// <param name="connection">The connection.</param>
+        /// <param name="pin">The pin.</param>
+        /// <param name="resistor">The resistor.</param>
+        /// <param name="polarity">The polarity.</param>
+        public Mcp23008InputBinaryPin(Mcp23008I2cConnection connection, Mcp23008Pin pin,
+            Mcp23008PinResistor resistor = Mcp23008PinResistor.None,
+            Mcp23008PinPolarity polarity = Mcp23008PinPolarity.Normal)
+        {
+            this.connection = connection;
+            this.pin = pin;
+
+            connection.SetDirection(pin, Mcp23008PinDirection.Input);
+            connection.SetResistor(pin, resistor);
+            connection.SetPolarity(pin, polarity);
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose(){}
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Reads the state of the pin.
+        /// </summary>
+        /// <returns>
+        ///   <c>true</c> if the pin is in high state; otherwise, <c>false</c>.
+        /// </returns>
+        public bool Read()
+        {
+            return connection.GetPinStatus(pin);
+        }
+
+        /// <summary>
+        /// Waits for the specified pin to be in the specified state.
+        /// </summary>
+        /// <param name="waitForUp">if set to <c>true</c> waits for the pin to be up. Default value is <c>true</c>.</param>
+        /// <param name="timeout">The timeout. Default value is <see cref="TimeSpan.Zero"/>.</param>
+        /// <remarks>If <c>timeout</c> is set to <see cref="TimeSpan.Zero"/>, a default timeout is used instead.</remarks>
+        public void Wait(bool waitForUp = true, TimeSpan timeout = new TimeSpan())
+        {
+            var startWait = DateTime.UtcNow;
+            if (timeout == TimeSpan.Zero)
+                timeout = DefaultTimeout;
+
+            while (Read() != waitForUp)
+            {
+                if (DateTime.UtcNow - startWait >= timeout)
+                    throw new TimeoutException("A timeout occurred while waiting for pin status to change");
+            }
+        }
+
+        #endregion
+
+    }
+}

--- a/Raspberry.IO.Components/Expanders/Mcp23008/Mcp23008OutputBinaryPin.cs
+++ b/Raspberry.IO.Components/Expanders/Mcp23008/Mcp23008OutputBinaryPin.cs
@@ -1,0 +1,58 @@
+﻿using System;
+
+namespace Raspberry.IO.Components.Expanders.Mcp23008
+{
+    /// <summary>
+    /// Represents a binary output pin on a MCP23008 I/O expander.
+    /// </summary>
+    public class Mcp23008OutputBinaryPin : IOutputBinaryPin
+    {
+        #region Properties
+
+        private readonly Mcp23008I2cConnection connection;
+        private readonly Mcp23008Pin pin;
+
+        #endregion
+
+                #region Instance Management
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Mcp23008OutputBinaryPin"/> class.
+        /// </summary>
+        /// <param name="connection">The connection.</param>
+        /// <param name="pin">The pin.</param>
+        /// <param name="resistor">The resistor.</param>
+        /// <param name="polarity">The polarity.</param>
+        public Mcp23008OutputBinaryPin(Mcp23008I2cConnection connection, Mcp23008Pin pin,
+            Mcp23008PinResistor resistor = Mcp23008PinResistor.None,
+            Mcp23008PinPolarity polarity = Mcp23008PinPolarity.Normal)
+        {
+            this.connection = connection;
+            this.pin = pin;
+
+            connection.SetDirection(pin, Mcp23008PinDirection.Output);
+            connection.SetResistor(pin, resistor);
+            connection.SetPolarity(pin, polarity);
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose(){}
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Writes the value of the pin.
+        /// </summary>
+        /// <param name="state">if set to <c>true</c>, pin is set to high state.</param>
+        public void Write(bool state)
+        {
+            connection.SetPinStatus(pin, state);
+        }
+
+        #endregion
+    }
+}

--- a/Raspberry.IO.Components/Expanders/Mcp23008/Mcp23008Pin.cs
+++ b/Raspberry.IO.Components/Expanders/Mcp23008/Mcp23008Pin.cs
@@ -1,0 +1,14 @@
+﻿namespace Raspberry.IO.Components.Expanders.Mcp23008
+{
+    public enum Mcp23008Pin
+    {
+        Pin0 = 0x0001,
+        Pin1 = 0x0002,
+        Pin2 = 0x0004,
+        Pin3 = 0x0008,
+        Pin4 = 0x0010,
+        Pin5 = 0x0020,
+        Pin6 = 0x0040,
+        Pin7 = 0x0080
+    }
+}

--- a/Raspberry.IO.Components/Expanders/Mcp23008/Mcp23008PinDirection.cs
+++ b/Raspberry.IO.Components/Expanders/Mcp23008/Mcp23008PinDirection.cs
@@ -1,0 +1,8 @@
+﻿namespace Raspberry.IO.Components.Expanders.Mcp23008
+{
+    public enum Mcp23008PinDirection
+    {
+        Input,
+        Output
+    }
+}

--- a/Raspberry.IO.Components/Expanders/Mcp23008/Mcp23008PinExtensionMethods.cs
+++ b/Raspberry.IO.Components/Expanders/Mcp23008/Mcp23008PinExtensionMethods.cs
@@ -1,0 +1,38 @@
+﻿namespace Raspberry.IO.Components.Expanders.Mcp23008
+{
+    /// <summary>
+    /// Provides extension methods for MCP23008 pins.
+    /// </summary>
+    public static class Mcp23008PinExtensionMethods
+    {
+        #region Methods
+
+        /// <summary>
+        /// Creates an output binary pin.
+        /// </summary>
+        /// <param name="connection">The connection.</param>
+        /// <param name="pin">The pin.</param>
+        /// <param name="resistor">The resistor.</param>
+        /// <param name="polarity">The polarity.</param>
+        /// <returns>The pin.</returns>
+        public static Mcp23008OutputBinaryPin Out(this Mcp23008I2cConnection connection, Mcp23008Pin pin, Mcp23008PinResistor resistor = Mcp23008PinResistor.None, Mcp23008PinPolarity polarity = Mcp23008PinPolarity.Normal)
+        {
+            return new Mcp23008OutputBinaryPin(connection, pin, resistor, polarity);
+        }
+
+        /// <summary>
+        /// Creates an input binary pin.
+        /// </summary>
+        /// <param name="connection">The connection.</param>
+        /// <param name="pin">The pin.</param>
+        /// <param name="resistor">The resistor.</param>
+        /// <param name="polarity">The polarity.</param>
+        /// <returns>The pin.</returns>
+        public static Mcp23008InputBinaryPin In(this Mcp23008I2cConnection connection, Mcp23008Pin pin, Mcp23008PinResistor resistor = Mcp23008PinResistor.None, Mcp23008PinPolarity polarity = Mcp23008PinPolarity.Normal)
+        {
+            return new Mcp23008InputBinaryPin(connection, pin, resistor, polarity);
+        }
+
+        #endregion
+    }
+}

--- a/Raspberry.IO.Components/Expanders/Mcp23008/Mcp23008PinPolarity.cs
+++ b/Raspberry.IO.Components/Expanders/Mcp23008/Mcp23008PinPolarity.cs
@@ -1,0 +1,8 @@
+﻿namespace Raspberry.IO.Components.Expanders.Mcp23008
+{
+    public enum Mcp23008PinPolarity
+    {
+        Normal,
+        Inverted
+    }
+}

--- a/Raspberry.IO.Components/Expanders/Mcp23008/Mcp23008PinResistor.cs
+++ b/Raspberry.IO.Components/Expanders/Mcp23008/Mcp23008PinResistor.cs
@@ -1,0 +1,8 @@
+﻿namespace Raspberry.IO.Components.Expanders.Mcp23008
+{
+    public enum Mcp23008PinResistor
+    {
+        None,
+        PullUp
+    }
+}

--- a/Raspberry.IO.Components/Raspberry.IO.Components.csproj
+++ b/Raspberry.IO.Components/Raspberry.IO.Components.csproj
@@ -111,6 +111,14 @@
     <Compile Include="Displays\Hd44780\Hd44780Pins.cs" />
     <Compile Include="Displays\Ssd1306\ScrollDirection.cs" />
     <Compile Include="Displays\Ssd1306\ScrollSpeed.cs" />
+    <Compile Include="Expanders\Mcp23008\Mcp23008I2cConnection.cs" />
+    <Compile Include="Expanders\Mcp23008\Mcp23008InputBinaryPin.cs" />
+    <Compile Include="Expanders\Mcp23008\Mcp23008OutputBinaryPin.cs" />
+    <Compile Include="Expanders\Mcp23008\Mcp23008Pin.cs" />
+    <Compile Include="Expanders\Mcp23008\Mcp23008PinDirection.cs" />
+    <Compile Include="Expanders\Mcp23008\Mcp23008PinExtensionMethods.cs" />
+    <Compile Include="Expanders\Mcp23008\Mcp23008PinPolarity.cs" />
+    <Compile Include="Expanders\Mcp23008\Mcp23008PinResistor.cs" />
     <Compile Include="Expanders\Mcp23017\Mcp23017InputBinaryPin.cs" />
     <Compile Include="Expanders\Mcp23017\Mcp23017OutputBinaryPin.cs" />
     <Compile Include="Expanders\Mcp23017\Mcp23017PinExtensionMethods.cs" />

--- a/RaspberrySharp.IO.sln
+++ b/RaspberrySharp.IO.sln
@@ -69,6 +69,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Raspberry.IO", "Raspberry.I
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Raspberry.IO.Interop", "Raspberry.IO.Interop\Raspberry.IO.Interop.csproj", "{689CB6C4-3D23-45DA-8E00-87C28AEA32D0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test.Gpio.MCP23008", "Tests\Test.Gpio.MCP23008\Test.Gpio.MCP23008.csproj", "{E401FE2A-7F73-41E7-9347-B51FEDAE71B9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -167,6 +169,10 @@ Global
 		{689CB6C4-3D23-45DA-8E00-87C28AEA32D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{689CB6C4-3D23-45DA-8E00-87C28AEA32D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{689CB6C4-3D23-45DA-8E00-87C28AEA32D0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E401FE2A-7F73-41E7-9347-B51FEDAE71B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E401FE2A-7F73-41E7-9347-B51FEDAE71B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E401FE2A-7F73-41E7-9347-B51FEDAE71B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E401FE2A-7F73-41E7-9347-B51FEDAE71B9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -191,6 +197,7 @@ Global
 		{0BB6C3CE-422E-49F2-9165-DEC06AFE1B1A} = {C39D0CC3-C0F2-4B58-8779-2CCB5B52534C}
 		{99EB3D1A-F0B7-454E-BB50-9B2F5349BC5B} = {C39D0CC3-C0F2-4B58-8779-2CCB5B52534C}
 		{CAF876A0-0FCB-44F7-96F1-53704CB6015F} = {C39D0CC3-C0F2-4B58-8779-2CCB5B52534C}
+		{E401FE2A-7F73-41E7-9347-B51FEDAE71B9} = {15ECD485-B3FD-4B6F-8491-7489DFFC89BC}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = Raspberry.IO.GeneralPurpose\Raspberry.IO.GeneralPurpose.csproj

--- a/Tests/Test.Gpio.HD44780/ConfigurationLoader.cs
+++ b/Tests/Test.Gpio.HD44780/ConfigurationLoader.cs
@@ -47,6 +47,7 @@ namespace Test.Gpio.HD44780
 
             const Mcp23008Pin registerSelectPin = Mcp23008Pin.Pin1;
             const Mcp23008Pin clockPin = Mcp23008Pin.Pin2;
+            const Mcp23008Pin backlightPin = Mcp23008Pin.Pin7;
 
             var dataPins = new[]
             {
@@ -64,7 +65,7 @@ namespace Test.Gpio.HD44780
             Console.WriteLine("\tData 2: {0}", dataPins[1]);
             Console.WriteLine("\tData 3: {0}", dataPins[2]);
             Console.WriteLine("\tData 4: {0}", dataPins[3]);
-            Console.WriteLine("\tBacklight: VCC");
+            Console.WriteLine("\tBacklight: {0}", backlightPin);
             Console.WriteLine("\tRead/write: GND");
             Console.WriteLine();
 
@@ -74,13 +75,17 @@ namespace Test.Gpio.HD44780
             var driver = new I2cDriver(sdaPin.ToProcessor(), sclPin.ToProcessor()) { ClockDivider = 512 };
             var connection = new Mcp23008I2cConnection(driver.Connect(address));
 
-            return new Hd44780Configuration(driver)
+            var retVal = new Hd44780Configuration(driver)
             {
                 Pins = new Hd44780Pins(
                     connection.Out(registerSelectPin),
                     connection.Out(clockPin),
                     dataPins.Select(pin => (IOutputBinaryPin)connection.Out(pin)))
             };
+
+            retVal.Pins.Backlight = connection.Out(backlightPin);
+
+            return retVal;
         }
 
         private static Hd44780Configuration LoadMcp23017Configuration(IEnumerable<string> args)

--- a/Tests/Test.Gpio.HD44780/ConfigurationLoader.cs
+++ b/Tests/Test.Gpio.HD44780/ConfigurationLoader.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Linq;
 using Raspberry.IO;
 using Raspberry.IO.Components.Displays.Hd44780;
+using Raspberry.IO.Components.Expanders.Mcp23008;
 using Raspberry.IO.Components.Expanders.Mcp23017;
 using Raspberry.IO.Components.Expanders.Pcf8574;
 using Raspberry.IO.GeneralPurpose;
@@ -21,6 +22,9 @@ namespace Test.Gpio.HD44780
 
         public static Hd44780Configuration FromArguments(string[] args)
         {
+            if (args.Contains("mcp23008", StringComparer.InvariantCultureIgnoreCase))
+                return LoadMcp23008Configuration(args);
+
             if (args.Contains("mcp23017", StringComparer.InvariantCultureIgnoreCase))
                 return LoadMcp23017Configuration(args);
 
@@ -33,6 +37,51 @@ namespace Test.Gpio.HD44780
         #endregion
         
         #region Private Helpers
+
+        private static Hd44780Configuration LoadMcp23008Configuration(IEnumerable<string> args)
+        {
+            var addressText = args.SkipWhile(s => !String.Equals(s, "mcp23008", StringComparison.InvariantCultureIgnoreCase)).Skip(1).DefaultIfEmpty("0x20").First();
+            var address = addressText.StartsWith("0x", StringComparison.InvariantCultureIgnoreCase)
+                ? Int32.Parse(addressText.Substring(2), NumberStyles.HexNumber)
+                : Int32.Parse(addressText);
+
+            const Mcp23008Pin registerSelectPin = Mcp23008Pin.Pin1;
+            const Mcp23008Pin clockPin = Mcp23008Pin.Pin2;
+
+            var dataPins = new[]
+            {
+                Mcp23008Pin.Pin3,
+                Mcp23008Pin.Pin4,
+                Mcp23008Pin.Pin5,
+                Mcp23008Pin.Pin6
+            };
+
+            Console.WriteLine();
+            Console.WriteLine("Using I2C connection over MCP23008 Expander");
+            Console.WriteLine("\tRegister Select: {0}", registerSelectPin);
+            Console.WriteLine("\tClock: {0}", clockPin);
+            Console.WriteLine("\tData 1: {0}", dataPins[0]);
+            Console.WriteLine("\tData 2: {0}", dataPins[1]);
+            Console.WriteLine("\tData 3: {0}", dataPins[2]);
+            Console.WriteLine("\tData 4: {0}", dataPins[3]);
+            Console.WriteLine("\tBacklight: VCC");
+            Console.WriteLine("\tRead/write: GND");
+            Console.WriteLine();
+
+            const ConnectorPin sdaPin = ConnectorPin.P1Pin03;
+            const ConnectorPin sclPin = ConnectorPin.P1Pin05;
+
+            var driver = new I2cDriver(sdaPin.ToProcessor(), sclPin.ToProcessor()) { ClockDivider = 512 };
+            var connection = new Mcp23008I2cConnection(driver.Connect(address));
+
+            return new Hd44780Configuration(driver)
+            {
+                Pins = new Hd44780Pins(
+                    connection.Out(registerSelectPin),
+                    connection.Out(clockPin),
+                    dataPins.Select(pin => (IOutputBinaryPin)connection.Out(pin)))
+            };
+        }
 
         private static Hd44780Configuration LoadMcp23017Configuration(IEnumerable<string> args)
         {

--- a/Tests/Test.Gpio.MCP23008/Program.cs
+++ b/Tests/Test.Gpio.MCP23008/Program.cs
@@ -1,0 +1,40 @@
+﻿#region References
+
+using System;
+using System.Threading;
+using Raspberry.IO.Components.Expanders.Mcp23008;
+using Raspberry.IO.GeneralPurpose;
+using Raspberry.IO.InterIntegratedCircuit;
+
+#endregion
+
+namespace Test.Gpio.MCP23008
+{
+    class Program
+    {
+        static void Main()
+        {
+            const ConnectorPin sdaPin = ConnectorPin.P1Pin03;
+            const ConnectorPin sclPin = ConnectorPin.P1Pin05;
+
+            Console.WriteLine("MCP-23008 Sample: Switch LED on Pin0 pin");
+            Console.WriteLine();
+            Console.WriteLine("\tSDA: {0}", sdaPin);
+            Console.WriteLine("\tSCL: {0}", sclPin);
+            Console.WriteLine();
+
+            using (var driver = new I2cDriver(sdaPin.ToProcessor(), sclPin.ToProcessor()))
+            {
+                var deviceConnection = new Mcp23008I2cConnection(driver.Connect(0x20));
+                deviceConnection.SetDirection(Mcp23008Pin.Pin0, Mcp23008PinDirection.Output);
+
+                while (!Console.KeyAvailable)
+                {
+                    deviceConnection.Toogle(Mcp23008Pin.Pin0);
+                    Thread.Sleep(1000);
+                }
+            }
+
+        }
+    }
+}

--- a/Tests/Test.Gpio.MCP23008/Properties/AssemblyInfo.cs
+++ b/Tests/Test.Gpio.MCP23008/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Test.Gpio.MCP23008")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Test.Gpio.MCP23008")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("9951e52d-ee54-4579-8eea-64a2e2e5a638")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Tests/Test.Gpio.MCP23008/Test.Gpio.MCP23008.csproj
+++ b/Tests/Test.Gpio.MCP23008/Test.Gpio.MCP23008.csproj
@@ -1,0 +1,79 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E401FE2A-7F73-41E7-9347-B51FEDAE71B9}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Test.Gpio.MCP23008</RootNamespace>
+    <AssemblyName>Test.Gpio.MCP23008</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Raspberry.IO.Components\Raspberry.IO.Components.csproj">
+      <Project>{8388cfca-e3db-43f7-b049-2cb195211ce8}</Project>
+      <Name>Raspberry.IO.Components</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Raspberry.IO.GeneralPurpose\Raspberry.IO.GeneralPurpose.csproj">
+      <Project>{281c71ed-c36d-408e-8baa-75c381dc17e7}</Project>
+      <Name>Raspberry.IO.GeneralPurpose</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Raspberry.IO.InterIntegratedCircuit\Raspberry.IO.InterIntegratedCircuit.csproj">
+      <Project>{63b8403e-bc56-43f9-a045-f61ecc3871f3}</Project>
+      <Name>Raspberry.IO.InterIntegratedCircuit</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>


### PR DESCRIPTION
Hello!

I'd like to submit for your consideration a change that I've added to provide support for the Adafruit i2c / SPI character LCD backpack (https://www.adafruit.com/products/292) which utilises the MCP23008 I/O Extender rather than the MCP23017 I/O Extender.