### PR TITLE
Upgraded references to Raspberry.System from 2.0.0 to 2.1.0

### DIFF
--- a/Raspberry.IO.Components/Raspberry.IO.Components.csproj
+++ b/Raspberry.IO.Components/Raspberry.IO.Components.csproj
@@ -31,12 +31,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Raspberry.System, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Raspberry.System.2.1\lib\net40\Raspberry.System.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Configuration" />
-    <Reference Include="Raspberry.System">
-      <HintPath>..\packages\Raspberry.System.2.0.0\lib\net40\Raspberry.System.dll</HintPath>
-    </Reference>
     <Reference Include="Common.Logging.Core">
       <HintPath>..\packages\Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
     </Reference>

--- a/Raspberry.IO.Components/packages.config
+++ b/Raspberry.IO.Components/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Common.Logging" version="3.3.1" targetFramework="net40" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net40" />
-  <package id="Raspberry.System" version="2.0.0" targetFramework="net40" />
+  <package id="Raspberry.System" version="2.1" targetFramework="net40" />
   <package id="UnitsNet" version="3.34.0" targetFramework="net40" />
 </packages>

--- a/Raspberry.IO.GeneralPurpose/Raspberry.IO.GeneralPurpose.csproj
+++ b/Raspberry.IO.GeneralPurpose/Raspberry.IO.GeneralPurpose.csproj
@@ -33,12 +33,13 @@
     <DocumentationFile>bin\Release\Raspberry.IO.GeneralPurpose.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Raspberry.System, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Raspberry.System.2.1\lib\net40\Raspberry.System.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="Raspberry.System">
-      <HintPath>..\packages\Raspberry.System.2.0.0\lib\net40\Raspberry.System.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\SharedAssemblyInfo.cs">
@@ -83,9 +84,6 @@
     <Compile Include="SwitchInputPinConfiguration.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\Raspberry.IO.Interop\Raspberry.IO.Interop.csproj">
       <Project>{689CB6C4-3D23-45DA-8E00-87C28AEA32D0}</Project>
       <Name>Raspberry.IO.Interop</Name>
@@ -94,6 +92,9 @@
       <Project>{ACE64F17-87E5-43E7-97A0-BDDE19059C61}</Project>
       <Name>Raspberry.IO</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/Raspberry.IO.GeneralPurpose/packages.config
+++ b/Raspberry.IO.GeneralPurpose/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Raspberry.System" version="2.0.0" targetFramework="net40" />
+  <package id="Raspberry.System" version="2.1" targetFramework="net40" />
 </packages>

--- a/Raspberry.IO.InterIntegratedCircuit/Raspberry.IO.InterIntegratedCircuit.csproj
+++ b/Raspberry.IO.InterIntegratedCircuit/Raspberry.IO.InterIntegratedCircuit.csproj
@@ -33,12 +33,13 @@
     <DocumentationFile>bin\Release\Raspberry.IO.InterIntegratedCircuit.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Raspberry.System, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Raspberry.System.2.1\lib\net40\Raspberry.System.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="Raspberry.System">
-      <HintPath>..\packages\Raspberry.System.2.0.0\lib\net40\Raspberry.System.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\SharedAssemblyInfo.cs">

--- a/Raspberry.IO.InterIntegratedCircuit/packages.config
+++ b/Raspberry.IO.InterIntegratedCircuit/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Raspberry.System" version="2.0.0" targetFramework="net40" />
+  <package id="Raspberry.System" version="2.1" targetFramework="net40" />
 </packages>

--- a/Raspberry.IO.SerialPeripheralInterface/Raspberry.IO.SerialPeripheralInterface.csproj
+++ b/Raspberry.IO.SerialPeripheralInterface/Raspberry.IO.SerialPeripheralInterface.csproj
@@ -33,15 +33,13 @@
     <DocumentationFile>bin\Release\Raspberry.IO.SerialPeripheralInterface.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Raspberry.System, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Raspberry.System.2.1\lib\net40\Raspberry.System.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="Raspberry.System">
-      <HintPath>..\packages\Raspberry.System.1.4.0\lib\net40\Raspberry.System.dll</HintPath>
-    </Reference>
-    <Reference Include="Raspberry.System, Version=1.2.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\Raspberry.System.2.0.0\lib\net40\Raspberry.System.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\SharedAssemblyInfo.cs">

--- a/Raspberry.IO.SerialPeripheralInterface/packages.config
+++ b/Raspberry.IO.SerialPeripheralInterface/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Raspberry.System" version="2.0.0" targetFramework="net40" />
+  <package id="Raspberry.System" version="2.1" targetFramework="net40" />
 </packages>

--- a/Tests/Test.Gpio.DHT11/Test.Gpio.DHT11.csproj
+++ b/Tests/Test.Gpio.DHT11/Test.Gpio.DHT11.csproj
@@ -34,6 +34,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Raspberry.System, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Raspberry.System.2.1\lib\net40\Raspberry.System.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
@@ -42,9 +46,6 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Raspberry.System">
-      <HintPath>..\..\packages\Raspberry.System.2.0.0\lib\net40\Raspberry.System.dll</HintPath>
-    </Reference>
     <Reference Include="UnitsNet, Version=3.34.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\UnitsNet.3.34.0\lib\net35\UnitsNet.dll</HintPath>
       <Private>True</Private>

--- a/Tests/Test.Gpio.DHT11/packages.config
+++ b/Tests/Test.Gpio.DHT11/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Raspberry.System" version="2.0.0" targetFramework="net40" />
+  <package id="Raspberry.System" version="2.1" targetFramework="net40" />
   <package id="UnitsNet" version="3.34.0" targetFramework="net40" />
 </packages>

--- a/Tests/Test.Gpio.HCSR04/Test.Gpio.HCSR04.csproj
+++ b/Tests/Test.Gpio.HCSR04/Test.Gpio.HCSR04.csproj
@@ -56,11 +56,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Raspberry.System, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Raspberry.System.2.1\lib\net40\Raspberry.System.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="Raspberry.System">
-      <HintPath>..\..\packages\Raspberry.System.2.0.0\lib\net40\Raspberry.System.dll</HintPath>
-    </Reference>
     <Reference Include="UnitsNet, Version=3.34.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\UnitsNet.3.34.0\lib\net35\UnitsNet.dll</HintPath>
       <Private>True</Private>

--- a/Tests/Test.Gpio.HCSR04/packages.config
+++ b/Tests/Test.Gpio.HCSR04/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Raspberry.System" version="2.0.0" targetFramework="net40" />
+  <package id="Raspberry.System" version="2.1" targetFramework="net40" />
   <package id="UnitsNet" version="3.34.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
This update has fixed the SSD1306 test application running on a Raspberry Pi 3. I believe this will fix the I2C issue on the RPi3, but has only been tested on this one component.