### PR TITLE
trivial spelling error

### DIFF
--- a/Raspberry.IO.InterIntegratedCircuit/I2cDriver.cs
+++ b/Raspberry.IO.InterIntegratedCircuit/I2cDriver.cs
@@ -374,7 +374,7 @@ namespace Raspberry.IO.InterIntegratedCircuit
                     throw new InvalidOperationException("No I2C device exist on the specified pins");
 
                 default:
-                    throw new NotSupportedException(string.Format(CultureInfo.InvariantCulture, "Connector pintout {0} is not supported", GpioConnectionSettings.ConnectorPinout));
+                    throw new NotSupportedException(string.Format(CultureInfo.InvariantCulture, "Connector pinout {0} is not supported", GpioConnectionSettings.ConnectorPinout));
             }
         }
 


### PR DESCRIPTION
Was receiving this error using an old version on a Pi 3.
wasn't sure what a `pintout` was :)