### PR TITLE
command line build scripts

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,2 @@
+powershell -f build.ps1 -configuration release
+powershell -f build.ps1 -configuration debug

--- a/build.common.ps1
+++ b/build.common.ps1
@@ -1,0 +1,90 @@
+$Script:UseWriteHost = $true
+
+if(!$Global:ColorScheme) {
+    $Global:ColorScheme = @{
+        "Banner"=[ConsoleColor]::Cyan
+        "RuntimeName"=[ConsoleColor]::Yellow
+        "Help_Header"=[ConsoleColor]::Yellow
+        "Help_Switch"=[ConsoleColor]::Green
+        "Help_Argument"=[ConsoleColor]::Cyan
+        "Help_Optional"=[ConsoleColor]::Gray
+        "Help_Command"=[ConsoleColor]::DarkYellow
+        "Help_Executable"=[ConsoleColor]::DarkYellow
+        "ParameterName"=[ConsoleColor]::Cyan
+        "Warning" = [ConsoleColor]::Yellow
+    }
+}
+
+function _WriteOut {
+    param(
+        [Parameter(Mandatory=$false, Position=0, ValueFromPipeline=$true)][string]$msg,
+        [Parameter(Mandatory=$false)][ConsoleColor]$ForegroundColor,
+        [Parameter(Mandatory=$false)][ConsoleColor]$BackgroundColor,
+        [Parameter(Mandatory=$false)][switch]$NoNewLine)
+
+    if($__TestWriteTo) {
+        $cur = Get-Variable -Name $__TestWriteTo -ValueOnly -Scope Global -ErrorAction SilentlyContinue
+        $val = $cur + "$msg"
+        if(!$NoNewLine) {
+            $val += [Environment]::NewLine
+        }
+        Set-Variable -Name $__TestWriteTo -Value $val -Scope Global -Force
+        return
+    }
+
+    if(!$Script:UseWriteHost) {
+        if(!$msg) {
+            $msg = ""
+        }
+        if($NoNewLine) {
+            [Console]::Write($msg)
+        } else {
+            [Console]::WriteLine($msg)
+        }
+    }
+    else {
+        try {
+            if(!$ForegroundColor) {
+                $ForegroundColor = $host.UI.RawUI.ForegroundColor
+            }
+            if(!$BackgroundColor) {
+                $BackgroundColor = $host.UI.RawUI.BackgroundColor
+            }
+
+            Write-Host $msg -ForegroundColor:$ForegroundColor -BackgroundColor:$BackgroundColor -NoNewLine:$NoNewLine
+        } catch {
+            $Script:UseWriteHost = $false
+            _WriteOut $msg
+        }
+    }
+}
+
+function _WriteConfig{
+param(
+        [Parameter(Mandatory=$true,Position=0)]$name,
+        [Parameter(Mandatory=$true,Position=1)]$value)
+		
+	_WriteOut -NoNewline -ForegroundColor $Global:ColorScheme.ParameterName "${name}: "
+	_WriteOut "$value"
+
+}
+
+function _DownloadNuget{
+param(
+        [Parameter(Mandatory=$true,Position=0)]$rootPath)
+
+$sourceNugetExe = "http://nuget.org/nuget.exe"
+$targetNugetExe = "$rootPath\nuget.exe"
+
+
+if(!(Test-Path $targetNugetExe )){
+    _WriteOut "Downloading nuget to $targetNugetExe"
+    Invoke-WebRequest $sourceNugetExe -OutFile $targetNugetExe
+}
+else{
+    # _WriteOut "nuget.exe is already present"
+}
+
+Set-Alias nuget $targetNugetExe -Scope Global
+
+}

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,43 @@
+param(
+    [string]$configuration = "Release"
+)
+
+. ".\build.common.ps1"
+
+$solutionName = "RaspberrySharp.IO"
+
+function init {
+    # Initialization
+    $global:rootFolder = Split-Path -parent $script:MyInvocation.MyCommand.Path
+    $global:rootFolder = Join-Path $rootFolder .
+    $global:packagesFolder = Join-Path $rootFolder packages
+    $global:outputFolder = Join-Path $rootFolder _artifacts
+    $global:msbuild = "C:\Program Files (x86)\MSBuild\14.0\Bin\MSBuild.exe"
+
+    _WriteOut -ForegroundColor $ColorScheme.Banner "-= $solutionName Build =-"
+    _WriteConfig "rootFolder" $rootFolder
+}
+
+function restorePackages{
+    _WriteOut -ForegroundColor $ColorScheme.Banner "nuget restore"
+    
+    New-Item -Force -ItemType directory -Path $packagesFolder
+    _DownloadNuget $packagesFolder
+    nuget restore
+}
+
+function buildSolution{
+
+    _WriteOut -ForegroundColor $ColorScheme.Banner "Build Solution"
+    & $msbuild "$rootFolder\$solutionName.sln" /p:Configuration=$configuration
+
+}
+
+
+init
+
+restorePackages
+
+buildSolution
+
+Write-Host "Build $configuration complete"


### PR DESCRIPTION
Hi there -  I didn't get a response on #69 so I just added some simple build scripts that I needed anyway.

I could expand and add automatic nuget packaging if you like but won't worry unless you think it would be a good addition. 

I needed this because I reference this solution as a git submodule so my project requires this project to be built so it can find the assemblies.

With this PR one can now drop to command line and execute `build.cmd` to compile both release and debug binaries....on windows of course, not raspbian.