### PR TITLE
* Update and Fix Nuget References

### DIFF
--- a/Raspberry.IO.Components/Raspberry.IO.Components.csproj
+++ b/Raspberry.IO.Components/Raspberry.IO.Components.csproj
@@ -31,20 +31,20 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Raspberry.System, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Raspberry.System.2.1\lib\net40\Raspberry.System.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Raspberry.System.2.1\lib\net40\Raspberry.System.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Configuration" />
     <Reference Include="Common.Logging.Core">
-      <HintPath>..\packages\Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
     </Reference>
     <Reference Include="Common.Logging">
-      <HintPath>..\packages\Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="UnitsNet, Version=3.34.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\UnitsNet.3.34.0\lib\net35\UnitsNet.dll</HintPath>
+    <Reference Include="UnitsNet, Version=3.46.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\UnitsNet.3.46.1\lib\net35\UnitsNet.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -194,4 +194,3 @@
   <ItemGroup />
   <ItemGroup />
 </Project>
-

--- a/Raspberry.IO.Components/packages.config
+++ b/Raspberry.IO.Components/packages.config
@@ -3,5 +3,5 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net40" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net40" />
   <package id="Raspberry.System" version="2.1" targetFramework="net40" />
-  <package id="UnitsNet" version="3.34.0" targetFramework="net40" />
+  <package id="UnitsNet" version="3.46.1" targetFramework="net40" />
 </packages>

--- a/Raspberry.IO.GeneralPurpose/Raspberry.IO.GeneralPurpose.csproj
+++ b/Raspberry.IO.GeneralPurpose/Raspberry.IO.GeneralPurpose.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Raspberry.System, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Raspberry.System.2.1\lib\net40\Raspberry.System.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Raspberry.System.2.1\lib\net40\Raspberry.System.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -104,4 +104,3 @@
   </Target>
   -->
 </Project>
-

--- a/Raspberry.IO.InterIntegratedCircuit/Raspberry.IO.InterIntegratedCircuit.csproj
+++ b/Raspberry.IO.InterIntegratedCircuit/Raspberry.IO.InterIntegratedCircuit.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Raspberry.System, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Raspberry.System.2.1\lib\net40\Raspberry.System.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Raspberry.System.2.1\lib\net40\Raspberry.System.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -71,4 +71,3 @@
   </Target>
   -->
 </Project>
-

--- a/Raspberry.IO.SerialPeripheralInterface/Raspberry.IO.SerialPeripheralInterface.csproj
+++ b/Raspberry.IO.SerialPeripheralInterface/Raspberry.IO.SerialPeripheralInterface.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Raspberry.System, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Raspberry.System.2.1\lib\net40\Raspberry.System.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Raspberry.System.2.1\lib\net40\Raspberry.System.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -94,4 +94,3 @@
   </Target>
   -->
 </Project>
-

--- a/Tests/Test.Gpio.DHT11/Test.Gpio.DHT11.csproj
+++ b/Tests/Test.Gpio.DHT11/Test.Gpio.DHT11.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Raspberry.System, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Raspberry.System.2.1\lib\net40\Raspberry.System.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Raspberry.System.2.1\lib\net40\Raspberry.System.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -45,8 +45,8 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="UnitsNet, Version=3.34.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\UnitsNet.3.34.0\lib\net35\UnitsNet.dll</HintPath>
+    <Reference Include="UnitsNet, Version=3.46.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\UnitsNet.3.46.1\lib\net35\UnitsNet.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -80,4 +80,3 @@
   </Target>
   -->
 </Project>
-

--- a/Tests/Test.Gpio.DHT11/packages.config
+++ b/Tests/Test.Gpio.DHT11/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Raspberry.System" version="2.1" targetFramework="net40" />
-  <package id="UnitsNet" version="3.34.0" targetFramework="net40" />
+  <package id="UnitsNet" version="3.46.1" targetFramework="net40" />
 </packages>

--- a/Tests/Test.Gpio.Ds1307/Test.Gpio.Ds1307.csproj
+++ b/Tests/Test.Gpio.Ds1307/Test.Gpio.Ds1307.csproj
@@ -40,7 +40,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/Test.Gpio.HCSR04/Test.Gpio.HCSR04.csproj
+++ b/Tests/Test.Gpio.HCSR04/Test.Gpio.HCSR04.csproj
@@ -56,13 +56,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Raspberry.System, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Raspberry.System.2.1\lib\net40\Raspberry.System.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Raspberry.System.2.1\lib\net40\Raspberry.System.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="UnitsNet, Version=3.34.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\UnitsNet.3.34.0\lib\net35\UnitsNet.dll</HintPath>
+    <Reference Include="UnitsNet, Version=3.46.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\UnitsNet.3.46.1\lib\net35\UnitsNet.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -104,4 +104,3 @@
   </Target>
   -->
 </Project>
-

--- a/Tests/Test.Gpio.HCSR04/packages.config
+++ b/Tests/Test.Gpio.HCSR04/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Raspberry.System" version="2.1" targetFramework="net40" />
-  <package id="UnitsNet" version="3.34.0" targetFramework="net40" />
+  <package id="UnitsNet" version="3.46.1" targetFramework="net40" />
 </packages>

--- a/Tests/Test.Gpio.MCP3008/Test.Gpio.MCP3008.csproj
+++ b/Tests/Test.Gpio.MCP3008/Test.Gpio.MCP3008.csproj
@@ -57,8 +57,8 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="UnitsNet, Version=3.34.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\UnitsNet.3.34.0\lib\net35\UnitsNet.dll</HintPath>
+    <Reference Include="UnitsNet, Version=3.46.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\UnitsNet.3.46.1\lib\net35\UnitsNet.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -100,4 +100,3 @@
   </Target>
   -->
 </Project>
-

--- a/Tests/Test.Gpio.MCP3008/packages.config
+++ b/Tests/Test.Gpio.MCP3008/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="UnitsNet" version="3.34.0" targetFramework="net40" />
+  <package id="UnitsNet" version="3.46.1" targetFramework="net40" />
 </packages>

--- a/Tests/Test.Gpio.Pca9685/Test.Gpio.Pca9685.csproj
+++ b/Tests/Test.Gpio.Pca9685/Test.Gpio.Pca9685.csproj
@@ -34,20 +34,20 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Common.Logging.Core, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="NDesk.Options">
-      <HintPath>..\..\packages\NDesk.Options.0.2.1\lib\NDesk.Options.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\NDesk.Options.0.2.1\lib\NDesk.Options.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="UnitsNet, Version=3.34.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\UnitsNet.3.34.0\lib\net35\UnitsNet.dll</HintPath>
+    <Reference Include="UnitsNet, Version=3.46.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\UnitsNet.3.46.1\lib\net35\UnitsNet.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -88,4 +88,3 @@
   </Target>
   -->
 </Project>
-

--- a/Tests/Test.Gpio.Pca9685/packages.config
+++ b/Tests/Test.Gpio.Pca9685/packages.config
@@ -3,5 +3,5 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net40" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net40" />
   <package id="NDesk.Options" version="0.2.1" targetFramework="net40" />
-  <package id="UnitsNet" version="3.34.0" targetFramework="net40" />
+  <package id="UnitsNet" version="3.46.1" targetFramework="net40" />
 </packages>

--- a/UnitTests/Tests.Raspberry.IO.Components/Tests.Raspberry.IO.Components.csproj
+++ b/UnitTests/Tests.Raspberry.IO.Components/Tests.Raspberry.IO.Components.csproj
@@ -32,17 +32,20 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FakeItEasy">
-      <HintPath>..\..\packages\FakeItEasy.1.25.2\lib\net40\FakeItEasy.dll</HintPath>
+    <Reference Include="FakeItEasy, Version=1.25.3.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\FakeItEasy.1.25.3\lib\net40\FakeItEasy.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions">
-      <HintPath>..\..\packages\FluentAssertions.3.3.0\lib\net40\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=4.6.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\FluentAssertions.4.6.3\lib\net40\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions.Core">
-      <HintPath>..\..\packages\FluentAssertions.3.3.0\lib\net40\FluentAssertions.Core.dll</HintPath>
+    <Reference Include="FluentAssertions.Core, Version=4.6.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\FluentAssertions.4.6.3\lib\net40\FluentAssertions.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -91,4 +94,3 @@
   </Target>
   -->
 </Project>
-

--- a/UnitTests/Tests.Raspberry.IO.Components/packages.config
+++ b/UnitTests/Tests.Raspberry.IO.Components/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="1.25.2" targetFramework="net40" />
-  <package id="FluentAssertions" version="3.3.0" targetFramework="net40" />
+  <package id="FakeItEasy" version="1.25.3" targetFramework="net40" />
+  <package id="FluentAssertions" version="4.6.3" targetFramework="net40" />
   <package id="NUnit" version="2.6.4" targetFramework="net40" />
 </packages>

--- a/UnitTests/Tests.Raspberry.IO.Interop/Tests.Raspberry.IO.Interop.csproj
+++ b/UnitTests/Tests.Raspberry.IO.Interop/Tests.Raspberry.IO.Interop.csproj
@@ -32,17 +32,20 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FakeItEasy">
-      <HintPath>..\..\packages\FakeItEasy.1.25.2\lib\net40\FakeItEasy.dll</HintPath>
+    <Reference Include="FakeItEasy, Version=1.25.3.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\FakeItEasy.1.25.3\lib\net40\FakeItEasy.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions">
-      <HintPath>..\..\packages\FluentAssertions.3.3.0\lib\net40\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=4.6.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\FluentAssertions.4.6.3\lib\net40\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions.Core">
-      <HintPath>..\..\packages\FluentAssertions.3.3.0\lib\net40\FluentAssertions.Core.dll</HintPath>
+    <Reference Include="FluentAssertions.Core, Version=4.6.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\FluentAssertions.4.6.3\lib\net40\FluentAssertions.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -83,4 +86,3 @@
   </Target>
   -->
 </Project>
-

--- a/UnitTests/Tests.Raspberry.IO.Interop/packages.config
+++ b/UnitTests/Tests.Raspberry.IO.Interop/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="1.25.2" targetFramework="net40" />
-  <package id="FluentAssertions" version="3.3.0" targetFramework="net40" />
+  <package id="FakeItEasy" version="1.25.3" targetFramework="net40" />
+  <package id="FluentAssertions" version="4.6.3" targetFramework="net40" />
   <package id="NUnit" version="2.6.4" targetFramework="net40" />
 </packages>

--- a/UnitTests/Tests.Raspberry.IO.SerialPeripheralInterface/Tests.Raspberry.IO.SerialPeripheralInterface.csproj
+++ b/UnitTests/Tests.Raspberry.IO.SerialPeripheralInterface/Tests.Raspberry.IO.SerialPeripheralInterface.csproj
@@ -34,14 +34,20 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions">
-      <HintPath>..\..\packages\FluentAssertions.3.3.0\lib\net40\FluentAssertions.dll</HintPath>
+    <Reference Include="FakeItEasy, Version=1.25.3.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\FakeItEasy.1.25.3\lib\net40\FakeItEasy.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions.Core">
-      <HintPath>..\..\packages\FluentAssertions.3.3.0\lib\net40\FluentAssertions.Core.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=4.6.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\FluentAssertions.4.6.3\lib\net40\FluentAssertions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="FluentAssertions.Core, Version=4.6.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\FluentAssertions.4.6.3\lib\net40\FluentAssertions.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -51,9 +57,6 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="FakeItEasy">
-      <HintPath>..\..\packages\FakeItEasy.1.25.2\lib\net40\FakeItEasy.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Interop\InteropSpec.cs" />
@@ -87,4 +90,3 @@
   </Target>
   -->
 </Project>
-

--- a/UnitTests/Tests.Raspberry.IO.SerialPeripheralInterface/packages.config
+++ b/UnitTests/Tests.Raspberry.IO.SerialPeripheralInterface/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="1.25.2" targetFramework="net40" />
-  <package id="FluentAssertions" version="3.3.0" targetFramework="net40" />
+  <package id="FakeItEasy" version="1.25.3" targetFramework="net40" />
+  <package id="FluentAssertions" version="4.6.3" targetFramework="net40" />
   <package id="NUnit" version="2.6.4" targetFramework="net40" />
 </packages>

--- a/UnitTests/Tests.Raspberry.IO/Tests.Raspberry.IO.csproj
+++ b/UnitTests/Tests.Raspberry.IO/Tests.Raspberry.IO.csproj
@@ -32,20 +32,20 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FakeItEasy, Version=2.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FakeItEasy.2.0.0\lib\net40\FakeItEasy.dll</HintPath>
+    <Reference Include="FakeItEasy, Version=1.25.3.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)packages\FakeItEasy.1.25.3\lib\net40\FakeItEasy.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FluentAssertions, Version=4.6.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.6.3\lib\net40\FluentAssertions.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\FluentAssertions.4.6.3\lib\net40\FluentAssertions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FluentAssertions.Core, Version=4.6.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.6.3\lib\net40\FluentAssertions.Core.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\FluentAssertions.4.6.3\lib\net40\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+      <HintPath>$(SolutionDir)packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -73,4 +73,3 @@
   </Target>
   -->
 </Project>
-

--- a/UnitTests/Tests.Raspberry.IO/packages.config
+++ b/UnitTests/Tests.Raspberry.IO/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="1.25.2" targetFramework="net40" />
-  <package id="FluentAssertions" version="3.3.0" targetFramework="net40" />
+  <package id="FakeItEasy" version="1.25.3" targetFramework="net40" />
+  <package id="FluentAssertions" version="4.6.3" targetFramework="net40" />
   <package id="NUnit" version="2.6.4" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Update reference path to "$(SolutionDir)packages\"
Update Nuget packages to working lastest version:
- FakeItEasy 1.25.3
- FluentAssertions 4.6.3
- UnitsNet 3.46.1.0