### PR TITLE
Added overload ctor for GpioConnectionSettings for cases when want to set driver manually.

### DIFF
--- a/Raspberry.IO.GeneralPurpose/GpioConnectionSettings.cs
+++ b/Raspberry.IO.GeneralPurpose/GpioConnectionSettings.cs
@@ -28,8 +28,18 @@ namespace Raspberry.IO.GeneralPurpose
         /// Initializes a new instance of the <see cref="GpioConnectionSettings"/> class.
         /// </summary>
         public GpioConnectionSettings()
+            : this(DefaultDriver)
         {
-            Driver = DefaultDriver;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GpioConnectionSettings"/> class
+        /// with the specified <see cref="IGpioConnectionDriver"/> 
+        /// </summary>
+        /// <param name="driver">Driver you want to work through.</param>
+        public GpioConnectionSettings(IGpioConnectionDriver driver)
+        {
+            Driver = driver;
             BlinkDuration = DefaultBlinkDuration;
             PollInterval = DefaultPollInterval;
             Opened = true;


### PR DESCRIPTION
Hello, guys!

It will be a nice feature to set GpioConnection.Driver instantly in ctor for cases if you want a specific one.

The issue source: for my device administrative model the user stands in gpio group but does not have permission to work with /dev/mem. So, when I create GpioSettings in standard way it causes to pick default driver and crash before settings created.

This tiny impovement is a way fix the situation.