### PR TITLE
Added support for Raspberry Pi model B.

### DIFF
--- a/Raspberry.IO.GeneralPurpose/GpioConnectionDriver.cs
+++ b/Raspberry.IO.GeneralPurpose/GpioConnectionDriver.cs
@@ -291,6 +291,7 @@ namespace Raspberry.IO.GeneralPurpose
         {
             switch (processor)
             {
+                case Processor.Bcm2835:
                 case Processor.Bcm2708:
                     return Interop.BCM2835_GPIO_BASE;
 

--- a/Raspberry.IO.GeneralPurpose/MemoryGpioConnectionDriver.cs
+++ b/Raspberry.IO.GeneralPurpose/MemoryGpioConnectionDriver.cs
@@ -247,6 +247,7 @@ namespace Raspberry.IO.GeneralPurpose
         {
             switch (processor)
             {
+				case Processor.Bcm2835:
                 case Processor.Bcm2708:
                     return Interop.BCM2835_GPIO_BASE;
 

--- a/Raspberry.IO.InterIntegratedCircuit/I2cDriver.cs
+++ b/Raspberry.IO.InterIntegratedCircuit/I2cDriver.cs
@@ -299,6 +299,7 @@ namespace Raspberry.IO.InterIntegratedCircuit
         {
             switch (processor)
             {
+                case Processor.Bcm2835:
                 case Processor.Bcm2708:
                     return Interop.BCM2835_BSC1_BASE;
 
@@ -314,6 +315,7 @@ namespace Raspberry.IO.InterIntegratedCircuit
         {
             switch (processor)
             {
+                case Processor.Bcm2835:
                 case Processor.Bcm2708:
                     return Interop.BCM2835_GPIO_BASE;
 


### PR DESCRIPTION
I've got quite an early Raspberry Pi model B, and when I tried to use I2C from the raspberry-sharp-io library I got errors because it didn't know about my processor type. I've simply added this, and tested with my Pi.

My Pi:
$cat /proc/cpuinfo
processor : 0
model name : ARMv6-compatible processor rev 7 (v6l)
BogoMIPS : 697.95
Features : half thumb fastmult vfp edsp java tls
CPU implementer : 0x41
CPU architecture: 7
CPU variant : 0x0
CPU part : 0xb76
CPU revision : 7

Hardware : BCM2835
Revision : 000f
Serial : XXX
